### PR TITLE
committee_roles.md: Make secretary solely responsibile for minutes

### DIFF
--- a/committee-roles.md
+++ b/committee-roles.md
@@ -35,18 +35,15 @@ The Chair agrees to:
 3.  Lead meetings fairly and transparently (or delegate meeting
     leadership when absent).
 
-4.  Ensure that minutes are kept and distributed (by delegation or
-    otherwise).
+4.  Facilitate the formation of necessary subcommittees.
 
-5.  Facilitate the formation of necessary subcommittees.
-
-6.  Ensure that SCF Steering Committee members are aware of their
+5.  Ensure that SCF Steering Committee members are aware of their
     governance duties and responsibilities.
 
-7.  Act as the primary liaison between the Executive Director and the
+6.  Act as the primary liaison between the Executive Director and the
     Steering Committee.
 
-8.  Serve as the primary liaison for communication between the
+7.  Serve as the primary liaison for communication between the
     community and the SCF Steering Committee members.
 
 
@@ -92,7 +89,9 @@ The Secretary is meant to maintain records of a non-financial nature. The Secret
 
 2. Circulate the meeting minutes privately among the members of the Committee for approval, allowing redactions within reason where requested.
 
-3. Manage, maintain, and facilitate other record keeping tasks where necessary.
+3. Archive and publish the approved meeting minutes [in the GitHub repository][minutes-repository].
+
+4. Manage, maintain, and facilitate other record keeping tasks where necessary.
 
 
 <a name="responsibilities"></a>
@@ -195,3 +194,5 @@ supportive of both the [Software Carpentry Foundation
 mission](https://github.com/swcarpentry/board/blob/master/mission-statement.md) 
 and the [Software Carpentry Code of 
 Conduct.](http://software-carpentry.org/conduct.html)
+
+[minutes-repository]: https://github.com/swcarpentry/board/tree/master/minutes


### PR DESCRIPTION
Don't pull in the chair.  Discussion behind this change [1,2,3,4],
with the argument for being:

On Fri, Jan 09, 2015 at 14:03:24PM -0800, Katy Huff wrote [2]:
> This statement is just supposed to indicate that the chair is
> supposed to make sure that the responsibilities of others are being
> met. They don't have to actually do it themselves. The secretary is
> expected to do it. See point 1 under the secretary.

I don't see a point in calling this out specifically, since the
chair's point 6 already covers keeping the other members on-task [2]:

  6. Ensure that SCF Steering Committee members are aware of their
     governance duties and responsibilities.

I also added explicit language about archiving/publishing the minutes,
since the existing secretary responsibilities only spoke about
generating and privately circulating the minutes.

Spun off from #5.

[1]: https://github.com/swcarpentry/board/pull/5#issuecomment-69405412
[2]: https://github.com/swcarpentry/board/pull/5#issuecomment-69406206
[3]: https://github.com/swcarpentry/board/pull/5#issuecomment-69406831
[4]: https://github.com/swcarpentry/board/pull/5#issuecomment-69407884