### PR TITLE
committee-roles.md: Don't sign the dedication definition

### DIFF
--- a/committee-roles.md
+++ b/committee-roles.md
@@ -109,9 +109,7 @@ members of the Software Carpentry community.  Additionally, since this is an
 activist Committee, its members are responsible for volunteering time toward 
 their own active [participation](#participation) in the Software Carpentry 
 community.  Finally, Committee members must be [dedicated](#dedication) to 
-Software Carpentry and the SCF as a whole. 
-
-Accordingly, these individuals will sign a statement of commitment declaring that they:
+Software Carpentry and the SCF as a whole. In particular, they:
 
 * <a name="communication"></a> Will Communicate
   * Will work with the rest of the team to communicate the organization's role to our most important audiences


### PR DESCRIPTION
There's no point in signing this, since the presense or absence of a
member's signature doesn't make this any more or less enforceable.  In
earlier discussion (1,2,3,4,5), the argument for signing seems to be:

On Fri, Jan 09, 2015 at 02:27:46PM -0800, Katy Huff wrote (4):
> I hear you, but, signing a document seemed an effective way to get
> the committee to internalize the gravity of their position.

I think we can trust the committee-election process to provide
dedicated committee members.  Concerns that a slacker might get
elected are better addressed with loss-of-confidence elections (#9)
than with an unenforceable initiation ritual.

1. https://github.com/swcarpentry/board/pull/5#issuecomment-69405685
2. https://github.com/swcarpentry/board/pull/5#issuecomment-69406360
3. https://github.com/swcarpentry/board/pull/5#issuecomment-69407414
4. https://github.com/swcarpentry/board/pull/5#issuecomment-69410381
5. https://github.com/swcarpentry/board/pull/5#issuecomment-69412275