### PR TITLE
committee-roles.md: Revise 3-hour rule include teaching

### DIFF
--- a/committee-roles.md
+++ b/committee-roles.md
@@ -120,7 +120,7 @@ Accordingly, these individuals will sign a statement of commitment declaring tha
 * <a name="participation"></a> Will Participate
   * Will contribute significantly to fund-raising and program activities, including assisting in bringing significant funding to the organization, such as offering names and introductions to potential donors, sponsors and grant  makers.
   * Will actively participate in all requests for their assistance and response.
-  * Will dedicate at least 3 volunteer hours per week toward Software Carpentry Foundation activities (including meeting attendance).
+  * Will dedicate at least 3 volunteer hours per week [toward Software Carpentry](#participation-methods).
   * Will offer their expertise to help ensure the health and success of the organization
 * <a name="dedication"></a> Will Be Dedicated
   * Will follow and exemplify the Software Carpentry Code of Conduct
@@ -163,28 +163,35 @@ The key pathways for communication with learners, instructors, and contributors 
 * Public Software Carpentry mailing lists (i.e. Discuss)
 
 
+<a name="participation-methods">
 ### Methods of Participation
 
-Participation must include 3 hours per week of Software Carpentry Foundation 
-volunteer time. This minimum total volunteer time includes time spent in 
-Steering Committee meetings.
+All steering committees have meetings, but Software Carpentry's
+activist committee must also engage in the wider Software Carpentry
+effort.  This helps advance assorted Software Carpentry projects and
+efforts, while also keeping committee members in touch with the wider
+Software Carpentry community.  The minimum [3 volunteer hours per
+week](#participation) may involve any of a number of activities that
+serve Software Carpentry.
 
-Participation may involve any of a number of activities that serve the Software 
-Carpentry Foundation. 
-
-- serving on subcommittees which serve the activities of the Steering Committee.
-- supporting initiatives prioritized by the Steering Committee and the Executive Director
+- serving on the committee (time in meetings, preparation for
+  meetings, and communicating committee activities with the
+  community).
+- organizing, instructing, or otherwise contributing to particular
+  events or workshops.
 - organizing and overseeing evaluation and assessment
 - organizing and overseeing mentorship activities
-- fund-raising, writing grant proposals, forming collaborations, encouraging 
-  community members to write grant proposals, etc.
-- writing blog posts, emails, and other updates to communicate Committee 
-  activities with the community
+- managing or contributing to lesson development (or template
+  development or other Software Carpentry tooling).
+- fund-raising, writing grant proposals, forming collaborations,
+  encouraging community members to write grant proposals, etc.
 - and much more...
 
-While continuing to be an instructor for workshops is welcomed, that work is 
-independent of the participation requirements and does not count toward the 
-requirement of 3 volunteer hours per week.
+As committee members, your committee responsibilities come first, so
+you shouldn't skip meetings or avoid posting meeting minutes because
+you've already put in three hours of workshop instruciton in a given
+week.  You should also try and spend your three hours each week; a
+period of intense work doesn't excuse two months of silence.
 
 ### Elements of Dedication
 


### PR DESCRIPTION
I've revised my position from #5 to include *both* teaching *and*
committee meetings, so I think we'll all be on board with this
pull-request.  Important points from earlier dicussion in #5
(1,2,3,4,5,6,7):

On Fri, Jan 09, 2015 at 02:27:46PM -0800, Katy Huff wrote (2):
> On Fri, Jan 09, 2015 at 02:07:43PM -0800, W. Trevor King wrote (1):
> > If you instruct a class, I'm certainly not going to get on your
> > case for not putting in an *additional* three hours of volunteer
> > time that week ;).  Or maybe "three hours a week" rolls over?  If
> > so, I think it would be good to make the commitment "12 hours a
> > month" or something else that doesn't roll over.  I don't want all
> > the committee members working like daemons in January and then
> > taking the rest of the year off ;).
>
> I see your complaint.  It does not roll over.  However, it was also
> not meant to be do-or-die.  It was meant to be a goalpost.  I agree
> it should be re-visited if folks are gaming the system or finding it
> too restrictive.  However, we want weekly effort from the committee
> members unless they are on vacation or otherwise.  On the topic of
> instruction.. the explanation is a little simpler.. we made the rule
> that instruction-doesnt-count in order to be explicit about what
> qualified as committee effort and what didn't.  If you teach a lot
> of workshops, great, but you still have to do committee work.
> That's the idea. Hope that helps?

On Fri, Jan 09, 2015 at 04:46:31PM -0800, Greg Wilson wrote (6):
> We're looking for 3 hours/week total from steering committee
> members, not 3 hours on top of committee duties.

So it sounds like the goal is:

* We want three hours a week of anything SWC-related, but don't shirk
  your committee responsibilities.

which is what I've aimed for here.

I've also removed "supporting initiatives prioritized by the Steering
Committee and the Executive Director", because that seems like a
catch-all category that's already handled by "and much more...".  If
it was covering some imporant class (or classes) of activities, I'd
rather list those classes explicitly to give folks a better idea of
what we mean.

Then I wrapped the "fund-raising" entry so it didnt' stick out so far
past the other entries ;).

(1): https://github.com/swcarpentry/board/pull/5#issuecomment-69407414
(2): https://github.com/swcarpentry/board/pull/5#issuecomment-69410381
(3): https://github.com/swcarpentry/board/pull/5#issuecomment-69412275
(4): https://github.com/swcarpentry/board/pull/5#issuecomment-69420926
(5): https://github.com/swcarpentry/board/pull/5#issuecomment-69422871
(6): https://github.com/swcarpentry/board/pull/5#issuecomment-69427061
(7): https://github.com/swcarpentry/board/pull/5#issuecomment-69429866