### PR TITLE
copy paste typo

### DIFF
--- a/membership.md
+++ b/membership.md
@@ -89,7 +89,7 @@ organizational membership:
 
     In return, the SCF:
 
-    a.  Invites the Partner to appoint a representative to its
+    a.  Invites the Affiliate to appoint a representative to its
         Advisory Council.
 
     b.  Reserves 2 seats in each online offering of the instructor


### PR DESCRIPTION
There was a typo in the membership doc. I just noticed it. This line should say Affiliate rather than Partner... because it's in the affiliate section.