### PR TITLE
governance.md: Specify Robert's Rules of Order as the default rule set

### DIFF
--- a/governance.md
+++ b/governance.md
@@ -184,7 +184,14 @@ Governance
         arrangements for Software Carpentry related activities without
         prior approval from the Steering Committee.
 
-10. The Steering Committee may amend these rules at any time by
+10. The rules contained in [Robert's Rules of Order Revised
+    (1921)][RRoO] shall govern the Foundation in all cases to which
+    they are applicable, and in which they are not inconsistent with
+    the by-laws or the special rules of this Foundation.
+
+11. The Steering Committee may amend these rules at any time by
     majority vote, and must re-approve these rules or an amended
     version of them every two years, beginning one year after its
     initial formation.
+
+[RRoO]: https://archive.org/details/Robertsrulesofor00robe_201303


### PR DESCRIPTION
Katy Huff pointed out that these are the existing rules used by the
committee [1].  This commit just makes that explicit.

I chose the 1921 edition (linked from the new text), because I wanted
the rules to be freely available, and the 1921 edition is out of
copyright in the United States (published in the U.S. before 1923
[2]).  I'm not sure about global copyright laws, but the U.S. is
fairly restrictive, so I expect the 1921 edition is in the public
domain in most other countries as well.  John Mark Ockerbloom says
Mexico recently extended their copyrights to lifetime of the author
plus 100 years [3], which would be 2024 (rounding up from May 1923 +
100) for Henry Martyn Robert [4].  Ockerbloom was unsure if that term
applied retroactively to older books.

The text I added is suggested by Robert on page 268 of the 1923
edition, except that I replaced "society" with "Foundation" to match
the rest of our constitution.

Among other things, these rules define a quorum for our steering
committee (p258):

  The quorum of a body of delagates, unless the by-laws provide for a
  smaller quorum, is a majority of the number enrolled as attending
  the convention, not those appointed.

He defines a majority vote (p24):

  A majority vote when used in these rules means a majority of the
  legal votes cast, ignoring blanks, at a legal meeting, a quorum
  being present.

And then says that a majority vote is the default (p43):

  Motions, as a general rule, require for their adoption only a
  majority vote—that is, a majority of the votes cast, a quorum being
  present; ...

Note that that's a majority of votes cast, not a majority of the
members.  There is an explicit example for a two-thirds vote on p204:

  A two-thirds vote means two-thirds of the votes cast, ignoring
  blanks which should never be counted.  This must not be confused
  with a vote of two-thirds of the members present, or two-thirds of
  the members, terms sometimes used in by-laws.  To illustrate the
  difference: Suppose 14 members vote on a question in a meeting of a
  society where 20 are present out of a total membership of 70, a
  two-thirds vote would be 10; a two-thirds vote of the members
  present would be 14; and a vote of two-thirds of the members would
  be 47.

Applying that to our seven-member steering committee, the quorum is
four members, and a meeting of four members with all members voting
can pass both majority and two-thirds votes with three members voting
for a motion.

[1]: https://github.com/swcarpentry/board/issues/10#issuecomment-77953151
[2]: http://www.copyright.gov/circs/circ15a.pdf
[3]: http://onlinebooks.library.upenn.edu/okbooks.html#whatpd
[4]: http://en.wikipedia.org/wiki/Henry_Martyn_Robert