### PR TITLE
proxy-membership.md: Allow proxy members

### DIFF
--- a/proxy-membership.md
+++ b/proxy-membership.md
@@ -1,0 +1,10 @@
+# Proxy members for the steering committee
+
+In the event that a member of the steering committee is temporarily
+unable to carry out their [duties][], they may appoint a proxy to act
+on their behalf, delegating any or all of their powers to the proxy
+member as they see fit.  A proxy must not be an existing committee
+member, and any single person may not be a proxy for more than one
+committee member at any given meeting.
+
+[duties]: committee-roles.md


### PR DESCRIPTION
Robert doesn't like proxies ([pp200-201][1]), with the following two
reasons:

* Non-members functioning as proxies breach the secrecy of
  members-only meetings.
* Members functioning as proxies unbalance the equality of members.

With a small, volunteer committee, I feel like the increased
perspective provided by proxy members outweighs the breach of secrecy.
Committee members are appointing proxies at their discretion, so they
are free to appoint trustworthy proxies or not appoint proxies at all
for particularly sensitive issues.  I estimate the risk of such
proxies leaking sensitive information is small, and the gain of having
a full complement of seven acting committee members is worth the risk.

I agree with Robert on the importance of balance within the committee,
so I've explicitly disallowed any (proxy) member from controlling
multiple votes.

Fixes #11.

[1]: https://archive.org/details/Robertsrulesofor00robe_201303