### PR TITLE
Added a privacy notice to be included in the etherpad at debriefing session

### DIFF
--- a/subcommittees/mentoring/Debriefing_privacy_notice.md
+++ b/subcommittees/mentoring/Debriefing_privacy_notice.md
@@ -1,0 +1,9 @@
+### Privacy Notice:
+
+Anything stated verbally or written down in the Etherpad during 
+Instructor debriefing sessions may be used at a later time point
+in a public blog post. 
+
+Information that instructors wish to discuss with the mentoring
+sub-committee in private should be directed to: 
+confidential@software-carpentry.org

--- a/subcommittees/mentoring/Debriefing_privacy_notice.md
+++ b/subcommittees/mentoring/Debriefing_privacy_notice.md
@@ -1,8 +1,8 @@
 ### Privacy Notice:
 
 Anything stated verbally or written down in the Etherpad during 
-Instructor debriefing sessions may be used at a later time point
-in a public blog post. 
+Instructor debriefing sessions will be considered public and may 
+be used at a later time point in a public blog post. 
 
 Information that instructors wish to discuss with the mentoring
 sub-committee in private should be directed to: 


### PR DESCRIPTION
@r-gaia-cs Please make any changes you see fit. I tried to make this clear and short as possible in the hopes that it will be read by everybody. 

In response to your email you sent to the instructors and mentoring lists, Trevor King suggested that when a private topic emerges we do discuss it at the debrief, but have the instructor state that they would like to speak off the record and we refrain from taking notes until we are back on the record. I did not include this in my brief privacy note because I think we as a mentorship committee should discuss it further. Your thoughts?