### PR TITLE
New Instructor Followup Procedures

### DIFF
--- a/checklists/instructor-followup/instructor-trainer.md
+++ b/checklists/instructor-followup/instructor-trainer.md
@@ -1,0 +1,33 @@
+Immediately after students have completed instructor training please
+send this concluding email:
+
+    Thanks again for taking part in Software Carpentry instructor training
+    - we're pleased to have you on the team.  When you have a minute,
+    please:
+
+    1. Take a moment to go to AMY [1] and update your profile so we know where
+        you are and what you're comfortable teaching - that will help us
+        match you with workshops.
+
+    2. Send me a three-line bio and a photo to add to our website (see
+        our team page [2] for examples).
+
+    3. Make sure you're on the 'instructors' mailing list (signup at [3])
+        so that you'll get notice about upcoming workshops that need
+        instructors - if you'd like us to help you organize one where you
+        are, please give me a shout.
+
+    Please also think about joining the discussion list (signup also at
+    [3]) - it's relatively low traffic, and high signal-to-noise, and it'd
+    be great to have your input. The SWC community also gathers on our
+    Slack channel [4] for real-time chat (get yourself an invite at [5]).
+
+    Hope to teach with you some day,
+    Thanks,
+    {{YOUR NAME HERE}}
+
+    [1] https://amy.software-carpentry.org/workshops/update_profile/
+    [2] https://software-carpentry.org/pages/team.html
+    [3] https://software-carpentry.org/pages/join.html
+    [4] https://swcarpentry.slack.com
+    [5] http://swc-slack-invite.herokuapp.com


### PR DESCRIPTION
Getting started on the new instructor followup procedures from swcarpentry/board_pvt#145:

> We need a procedure document that describes the who, how, and when of what to do when an instructor completes instructor training. That includes, in particular, how to introduce them to the instructor mailing and other communication channels, how to get them connected to their first workshop, how to help them organize a workshop nearby if none are available, potentially how to pair them with more senior instructors, and, in particular, what emails to send to that instructor to see how they're doing, where they want to teach, whether their institution wants to be a partner, etc.

Note that this creates a new "checklists" directory here in the board repo where we can put these such things (in simple Markdown format), but I'm open to other locations.

Other things I'm thinking of adding are a followup from the mentoring committee lead if the instructor hasn't taught within six months (this would require a notification from AMY) and an email from the executive director about institutional partnership.