### PR TITLE
Move whitespaces to improve readability.

### DIFF
--- a/elections/2016/results.md
+++ b/elections/2016/results.md
@@ -6,21 +6,21 @@ Our election official for 2016 SC election was Tim Cerino.
 note there is a 2-way tie for sixth place
 
 ~~~
- 1** -  Raniere Silva :  79 votes  -11.1%
- 2** -  Karin Lagesen :  73 votes  -10.3%
- 3** -  Bill Mills :  68 votes  -9.6%
- 4** -  Kate Hertweck :  64 votes  -9.0%
- 5** -  Belinda Weaver :  62 votes  -8.7%
- 6** -  Rayna Harris :  55 votes  -7.7%
- 6** -  Jason Williams :  55 votes  -7.7%
+ 1** -  Raniere Silva :  79 votes - 11.1%
+ 2** -  Karin Lagesen :  73 votes - 10.3%
+ 3** -  Bill Mills :  68 votes - 9.6%
+ 4** -  Kate Hertweck :  64 votes - 9.0%
+ 5** -  Belinda Weaver :  62 votes - 8.7%
+ 6** -  Rayna Harris :  55 votes - 7.7%
+ 6** -  Jason Williams :  55 votes - 7.7%
  - - - - - - - - - - - - - - - - - - - - - - 
- 8   -  Anelda van der Walt :  52 votes  -7.3%
- 9   -  Dhavide Aruliah :  42 votes  -5.9%
-10   -  Giacomo Peru :  41 votes  -5.8%
-11   -  Lauren Michael :  37 votes  -5.2%
-12   -  Cam Macdonell :  33 votes  -4.6%
-13   -  Leanne Wake :  31 votes  -4.4%
-14   -  Jonathan Guyer :  18 votes  -2.5%
+ 8   -  Anelda van der Walt :  52 votes - 7.3%
+ 9   -  Dhavide Aruliah :  42 votes - 5.9%
+10   -  Giacomo Peru :  41 votes - 5.8%
+11   -  Lauren Michael :  37 votes - 5.2%
+12   -  Cam Macdonell :  33 votes - 4.6%
+13   -  Leanne Wake :  31 votes - 4.4%
+14   -  Jonathan Guyer :  18 votes - 2.5%
 ~~~
 
 


### PR DESCRIPTION
Followed convention (notation) used in second section.
Otherwise it looks like we are dealing with percent variations (as in, -7% wrt previous results).
Thanks!