### PR TITLE
Procedure for combined instructor discussion sessions

### DIFF
--- a/subcommittees/mentoring/procedure-discussion-session.md
+++ b/subcommittees/mentoring/procedure-discussion-session.md
@@ -13,8 +13,8 @@ are organized and conducted.
     where instructors share experiences from teaching and
     obtain information while preparing to teach.
 
--   **Facilitator**: is a member of the Mentoring Subcommittee
-    who hosts a discussion session.
+-   **Host**: member of the Mentoring Subcommittee
+    who facilitates a discussion session.
 
 ## Motivation
 
@@ -37,7 +37,7 @@ the instructor discussion sessions so that
 
 -   instructors are notified at least one week in advance and
 
--   each session has at least one facilitator (preferably two) to conduct the discussion.
+-   each session has at least one host (preferably two) to conduct the discussion.
 
 Meeting scheduling will be coordinated via [etherpad](http://pad.software-carpentry.org/instructor-discussion).
 
@@ -79,10 +79,10 @@ The agenda should be similar to the following:
     - For big problems or concerns, start an issue on GitHub in the appropriate lesson or add to Google Doc of commonly mentioned concerns
     - For small typos, submit pull request to appropriate lesson
 
-Each instructor discussion session session must have at least one facilitator
+Each instructor discussion session session must have at least one host
 from the mentoring subcommittee (although two hosts are preferred). 
 
-The **facilitator** is responsible for: 
+The **host** is responsible for: 
 
 - hosting the meeting and facilitating discussion using the agenda described on the 
 [etherpad](http://pad.software-carpentry.org/instructor-discussion). 
@@ -101,14 +101,17 @@ questions described in the checkout procedure.
 
 ## After the meeting
 
-The facilitator of the meeting should report back to the lead instructor trainer and 
+The host of the meeting should report back to the lead instructor trainer and 
 describe whether newly trained instructors participating as a part of the checkout procedure 
 were engaged and could answer target questions described in the checkout procedure.
 
-The facilitator of the meeting should 1) archive the etherpad and 2) clean the etherpad for the next user. To archive, click the star in the top left corner. This will save a copy of the etherpad in its current state. Then, the faciliator should delete all the community added comments and change the dates to prepare the etherpad for the next session
+The host of the meeting should 1) archive the etherpad and 2) clean the etherpad for the next user. To archive, click the star in the top left corner. This will save a copy of the etherpad in its current state. Then, the faciliator should delete all the community added comments and change the dates to prepare the etherpad for the next session
 
-Each month, the facilitators of discussion sessions will
-coordinate to write a blog post summarizing the topics discussed.
+The hosts of discussion sessions may choose to 
+write a blog post summarizing topics discussed, including 
+(but not limited to) the following: implementation of new lessons, 
+recurring questions about or problems while teaching, and general strategies for 
+instructing workshops. 
 [This template](template-blog-about-debriefing-session.md) can be used
 as the start point for the blog post.
 

--- a/subcommittees/mentoring/procedure-discussion-session.md
+++ b/subcommittees/mentoring/procedure-discussion-session.md
@@ -1,0 +1,94 @@
+# Procedure - Instructor Discussion Session
+
+This document describes how instructor discussion sessions
+are organized and conducted.
+
+## Terminology
+
+-   **SCF**: Software Carpentry Foundation.
+
+-   **DC**: Data Carpentry.
+
+-   **Instructor discussion session**: an online meeting
+    where instructors share experiences from teaching and
+    obtain information while preparing to teach.
+
+-   **Facilitator**: is a member of the Mentoring Subcommittee
+    who hosts a discussion session.
+
+## Motivation
+
+1.  SCF and DC are community based projects
+    and the community needs opportunity to interact.
+
+2.  SCF and DC believe in jugyokenkyu, or "lesson study",
+    and evidence-based education so instructors need opportunity to share experiences.
+
+3. SCF and DC are continuing to increase the number of instructors
+   and develop new lessons. New instructors would like to hear from 
+   experienced teachers who have recently taught to help prepare for upcoming workshops.
+
+## Before the meeting
+
+The Mentoring Subcommittee is responsible for organizing
+the instructor discussion sessions so that
+
+-   each month has at least four discussion sessions,
+
+-   instructors are notified at least one week in advance and
+
+-   each session has at least one facilitator (preferably two) to conduct the discussion.
+
+Meeting scheduling will be coordinated via (etherpad)[http://pad.software-carpentry.org/instructor-discussion].
+
+The dates of instructor discussion sessions are also listed
+in the SCF community calendar,
+https://calendar.google.com/calendar/embed?src=oseuuoht0tvjbokgg3noh8c47g%40group.calendar.google.com.
+
+Email invitations should be sent to three groups of instructors:
+
+- instructors who have taught in the previous two weeks
+
+- instructors who are preparing to teach in the next 4-6 weeks
+
+- folks who have recently completed instructor training and need to
+  attend a discussion session to complete their checkout
+
+The contact information for the first two groups is available in (AMY)[https://amy.software-carpentry.org/workshops/]. 
+The chair of the mentoring subcommittee, as well as all members of the SCF Steering committee, 
+should have access to AMY. Newly trained instructors should be directed to instructor discussion sessions 
+following completion of instructor training.
+
+## During the meeting
+
+Meetings will be hosted via (etherpad)[http://pad.software-carpentry.org/instructor-discussion].
+
+Each instructor discussion session session must have at least one facilitator
+from the mentoring subcommittee (although two hosts are preferred). 
+
+The **facilitator** is responsible for: 
+
+- hosting the meeting and facilitating discussion using the agenda described on the 
+(etherpad)[http://pad.software-carpentry.org/instructor-discussion]. 
+
+- ensuring instructors teaching in the near future have urgent questions or concerns addressed.
+
+- aggregating feedback from instructors who have recently taught.
+
+- engaging newly trained instructors and evaluating their participating using a subset of 
+questions described in the checkout procedure.
+
+- encouraging attendees to create issues or pull requests to correct problems.
+
+
+## After the meeting
+
+The facilitator of the meeting should report back to the lead instructor trainer and 
+describe whether newly trained instructors participating as a part of the checkout procedure 
+were engaged and could answer target questions described in the checkout procedure.
+
+Each month, the facilitators of discussion sessions will
+coordinate to write a blog post summarizing the topics discussed.
+[This template](template-blog-about-debriefing-session.md) can be used
+as the start point for the blog post.
+

--- a/subcommittees/mentoring/procedure-discussion-session.md
+++ b/subcommittees/mentoring/procedure-discussion-session.md
@@ -52,7 +52,7 @@ Email invitations should be sent to three groups of instructors:
 - instructors who are preparing to teach in the next 4-6 weeks
 
 - folks who have recently completed instructor training and need to
-  attend a discussion session to complete their checkout
+  attend a discussion session to complete their [checkout](http://swcarpentry.github.io/instructor-training//11-checkout/)
 
 The contact information for the first two groups is available in [AMY](https://amy.software-carpentry.org/workshops/). 
 The chair of the mentoring subcommittee, as well as all members of the SCF Steering committee, 
@@ -74,8 +74,10 @@ The agenda should be similar to the following:
     - Any changes or additions to lesson material?
 - Preparing for upcoming workshops
     - Specific questions about teaching and/or lessons?
-    - If you are attending for instructor training checkout: have you asked a question yet?
-- Reminder: 
+- Preparing for instructor training checkout
+    - Questions about checkout procedure, lessons, or workshop organization?
+    - Have you asked a question here yet?
+- Reminder to discussion session participants: 
     - For big problems or concerns, start an issue on GitHub in the appropriate lesson or add to Google Doc of commonly mentioned concerns
     - For small typos, submit pull request to appropriate lesson
 

--- a/subcommittees/mentoring/procedure-discussion-session.md
+++ b/subcommittees/mentoring/procedure-discussion-session.md
@@ -63,6 +63,22 @@ following completion of instructor training.
 
 Meetings will be hosted via [etherpad](http://pad.software-carpentry.org/instructor-discussion).
 
+The agenda should be similar to the following:
+
+- Welcome and host introduction
+- Attendees introduction
+    - Name, affiliation/position, purpose for attending
+- Report from previous workshops
+    - What worked the best during your workshop?
+    - What was the biggest hurdle?
+    - Any changes or additions to lesson material?
+- Preparing for upcoming workshops
+    - Specific questions about teaching and/or lessons?
+    - If you are attending for instructor training checkout: have you asked a question yet?
+- Reminder: 
+    - For big problems or concerns, start an issue on GitHub in the appropriate lesson or add to Google Doc of commonly mentioned concerns
+    - For small typos, submit pull request to appropriate lesson
+
 Each instructor discussion session session must have at least one facilitator
 from the mentoring subcommittee (although two hosts are preferred). 
 
@@ -71,9 +87,11 @@ The **facilitator** is responsible for:
 - hosting the meeting and facilitating discussion using the agenda described on the 
 [etherpad](http://pad.software-carpentry.org/instructor-discussion). 
 
+- maintaining focus on the main goal of the session, which is to share ideas and keep instructors excited about teaching.
+
 - ensuring instructors teaching in the near future have urgent questions or concerns addressed.
 
-- aggregating feedback from instructors who have recently taught.
+- collecting feedback from instructors who have recently taught.
 
 - engaging newly trained instructors and evaluating their participating using a subset of 
 questions described in the checkout procedure.
@@ -87,7 +105,7 @@ The facilitator of the meeting should report back to the lead instructor trainer
 describe whether newly trained instructors participating as a part of the checkout procedure 
 were engaged and could answer target questions described in the checkout procedure.
 
-The facilitator of the meeting should 1) archive the etherpad and 2) clean the etherpad for the next user. To archie, click the star in the top left corner. This will save a copy of the etherpad in its current state. Then, the faciliator should delete all the community added comments and change the dates to prepare the etherpad for the next session
+The facilitator of the meeting should 1) archive the etherpad and 2) clean the etherpad for the next user. To archive, click the star in the top left corner. This will save a copy of the etherpad in its current state. Then, the faciliator should delete all the community added comments and change the dates to prepare the etherpad for the next session
 
 Each month, the facilitators of discussion sessions will
 coordinate to write a blog post summarizing the topics discussed.


### PR DESCRIPTION
I used the previous procedure-debriefing-session.md as a template for this document. I've left it as general as possible for the time being, but believe it could be improved by adding the following:

- cleaning up etherpad at end of each session (is this a responsibility of each session's host?)

- specifying who sends invitations to instructors, and on what schedule

Comments and changes are welcome!