### PR TITLE
subcommittees/subcommittees.md: Greg no longer executive director

### DIFF
--- a/subcommittees/subcommittees.md
+++ b/subcommittees/subcommittees.md
@@ -5,7 +5,7 @@
 - SCF Liaison: Jason Williams
 - Description: The finance subcommittee recommends financial policies and budgets that support the mission and goals of the Software Carpentry Foundation (SCF). The committee reviews all financial activities and  monthly reports on SCF’s financial performance against our budget goals and purposes.
 - Members:
-  - Greg Wilson, ED
+  - Greg Wilson
   - Jason Williams
   - Josh Greenberg
   - Katy Huff


### PR DESCRIPTION
This line landed in bb3d491 (fixes #18 ? @jiffyclub, can you merge?,
2015-03-06, #21).  I'm not sure if Greg's still on the committee or
not, but the ED annotation is stale.  And there's probably not a need
for that sort of annotation in the member entries anyway.