### PR TITLE
encourage all co-instructors to attend

### DIFF
--- a/subcommittees/mentoring/files/pre_workshop_email.txt
+++ b/subcommittees/mentoring/files/pre_workshop_email.txt
@@ -17,6 +17,10 @@ for the most convenient time on this etherpad:
 On the day of the meeting, connection information will be posted on the
 same etherpad.
 
+We encourage all workshop co-insturctors to attend the same discussion 
+session for maxmium benefit to your growth as an insturctor and member 
+of the community. 
+
 We hope to see you in the next few weeks!
 
 Cheers,


### PR DESCRIPTION
I started thinking more about potential ways to module the number of attendees and workshops at our discussion session. One potentially easy way to achieve our ideal numbers is to be more clear about inviting co-instructors to attend the same discussion session. 

What do you think about adding a sentence like this? How could this sentence be improved?

@ChristinaLK @tracykteal @maneesha @smcclatchy 


   