### PR TITLE
governance: Soften "week" to "month" for minute turnaround

### DIFF
--- a/governance.md
+++ b/governance.md
@@ -30,7 +30,7 @@ Governance
         online.
 
     b.  Minutes of the Steering Committee's meetings must be published
-        within one week of each meeting.
+        within one month of each meeting.
 
 4.  <a name="steering-committee-elections"></a>
     The Steering Committee is re-elected annually.


### PR DESCRIPTION
The week turnaround is a nice stretch goal, but it's a hard to square with the requirement for [internally vetting minutes before publication][1].  We did actually get 7-day turnaround twice (a4fdbde and 637fbb7, found by looking through `git log --stat --format='%h %cd %s' --date=short minutes`), but I expect one of these requirements has to give, and since the experience so far has been to publish the notes within a month or two of the meeting, this commit relaxes the timing a bit.

I've kept the month requirement (vs. two months, etc.), because having the minutes published before the *next* meeting gives non-members enough visibility to avoid duplicating already-resolved/rejected committee proposals.  However, actually pinning the publication to “before the next meeting” would unduly burden emergency meetings (“before we get to $EMERGENCY, can we approve last week's minutes?”).

[1]: https://github.com/swcarpentry/board/blame/73920cb2369b502d7780e4957943a809401925b3/committee-roles.md#L90