### PR TITLE
subcommittees/mentoring/README.md: Tiffany on temporary leave

### DIFF
--- a/subcommittees/mentoring/README.md
+++ b/subcommittees/mentoring/README.md
@@ -42,7 +42,7 @@ list](#mailing-list).
 
 ## Steering Comittee Liaison
 
-* LIAISON_NAME (@LIAISON_GITHUB_USER, OTHER_LIAISON_CONTACT)
+* Rayna Harris (@raynamharris, [@raynamharris](https://twitter.com/raynamharris))
 
 ## Current Members
 

--- a/subcommittees/mentoring/README.md
+++ b/subcommittees/mentoring/README.md
@@ -59,12 +59,12 @@ list](#mailing-list).
 * Phil Rosenfield (@philrosenfield, [@philrosenfield](https://twitter.com/philrosenfield))
 * Rayna Harris (@raynamharris, [@raynamharris](https://twitter.com/raynamharris))
 * Susan McClatchy (@smcclatchy, [@SueMcclatchy](https://twitter.com/SueMcclatchy))
-* Tiffany Timbers (@ttimbers, [@TiffanyTimbers](https://twitter.com/TiffanyTimbers))
 * Tracy Teal (@tracykteal, [@tracykteal](https://twitter.com/tracykteal))
 
 ## Past Members
 
 * Sheldon McKay (@mckays630)
+* Tiffany Timbers (@ttimbers, [@TiffanyTimbers](https://twitter.com/TiffanyTimbers))
 
 [blog]: https://software-carpentry.org/blog/
 [blog-archives]: https://software-carpentry.org/blog/categories/#SLUG


### PR DESCRIPTION
On Wed, Jan 04, 2017 at 01:59:42PM -0800, Tiffany Timbers [wrote][1]:
> Given that I am pregnant, and going on Maternity leave from Feb - Sept this year, I will be taking an official temporary leave from Mentorship committee. I anticipate being able to fully engage again as an active volunteer in Sept.

We could mark this up with an “on leave” in the current members section, but to keep things simple I've just moved her to the past-members section.  We'll move her back to the current members section in September.

[1]: http://lists.software-carpentry.org/pipermail/mentoring/2017-January/000761.html