### PR TITLE
subcommittees/mentoring/README: Remove "We don't have any past members"

### DIFF
--- a/subcommittees/mentoring/README.md
+++ b/subcommittees/mentoring/README.md
@@ -65,9 +65,6 @@ list](#mailing-list).
 
 * Sheldon McKay (@mckays630)
 
-We don't have any past members yet!  When current members leave the
-subcommittee we will move their entries into this section.
-
 [blog]: https://software-carpentry.org/blog/
 [blog-archives]: https://software-carpentry.org/blog/categories/#SLUG
 [mailing-list]: http://lists.software-carpentry.org/listinfo/SLUG


### PR DESCRIPTION
We do (Sheldon).  Removing this paragraph fixes a copy/paste error from #149.