### PR TITLE
elections/2017: Add election results

### DIFF
--- a/elections/2017/results.md
+++ b/elections/2017/results.md
@@ -1,0 +1,36 @@
+Our election official for 2017 SC election was Jonah Duckles.
+
+## Ranked results
+
+There is a 2-way tie for fourth place.
+
+~~~
+1. Christina Koch  120 votes - 15.4%
+2. Belinda Weaver  117 votes - 15.1%
+3. Mateusz Kuzak   113 votes - 14.5%
+4. Karin Lagesen   110 votes - 14.2%
+4. Kate Hertweck   110 votes - 14.2%
+6. Rayna Harris    108 votes - 13.9%
+7. Sue McClatchy   99 votes - 12.7%
+~~~
+
+## Raw results
+
+Raw results from ElectionBuddy are:
+
+~~~
+Election Type: Plurality Voting (First Past the Post)
+Started at: January 23, 2017 2:30pm UTC
+Finished at: January 27, 2017 11:59pm UTC
+
+176 of 557 ballots cast.
+
+Christina Koch  120 votes - 15.4%
+Belinda Weaver  117 votes - 15.1%
+Mateusz Kuzak   113 votes - 14.5%
+Karin Lagesen   110 votes - 14.2%
+Kate Hertweck   110 votes - 14.2%
+Rayna Harris    108 votes - 13.9%
+Sue McClatchy   99 votes - 12.7%
+Abstained       17
+~~~


### PR DESCRIPTION
Modeled on the 2016 results, but with [this year's data][1].  I haven't been able to find an official start time for this election, so I'm rounding the `Date` header on the ballot email I received to the nearest half hour and using that.

[1]: https://electionbuddy.com/elections/38135/results/ghpsxpygd