### PR TITLE
adding subcommittee directory for CoC/policy group

### DIFF
--- a/subcommittees/README.md
+++ b/subcommittees/README.md
@@ -21,6 +21,7 @@ task).
 * [Finance](finance/README.md)
 * [Lesson Organization and Develpment](lessons/README.md)
 * [Partner Relations and Fundraising](partner-relations/README.md)
+* [Code of Conduct and Policy](policy-CoC/README.md)
 
 ## Former Subcommittees
 

--- a/subcommittees/policy-CoC/README.md
+++ b/subcommittees/policy-CoC/README.md
@@ -1,0 +1,57 @@
+# The NAME Subcommittee
+
+## Purpose and Scope
+
+The Subcommittee FIXME...
+
+## What We Do
+
+FIXME
+
+## Related Projects
+
+FIXME
+
+## Measuring Progress
+
+FIXME
+
+## Mailing List
+
+The best way to contact this Subcommittee is via the [mailing
+list][mailing-list], which is archived [here][mailing-list-archives].
+
+## Outreach
+
+We [blog][] about our ongoing and proposed activities.  Past blog
+posts are available [here][blog-archives].
+
+## Meetings
+
+We have occasional meetings.  Minutes of past meetings are available
+[here](minutes).
+
+## Join Us!
+
+We welcome new members to the Subcommittee.  If you are interested in
+joining our community-building efforts, please email the [mailing
+list](#mailing-list).
+
+## Steering Comittee Liaison
+
+* LIAISON_NAME (@LIAISON_GITHUB_USER, OTHER_LIAISON_CONTACT)
+
+## Current Members
+
+* MEMBER_1_NAME (@MEMBER_1_GITHUB_USER, OTHER_MEMBER_1_CONTACT)
+* OTHER_MEMBERS...
+
+## Past Members
+
+We don't have any past members yet!  When current members leave the
+Subcommittee we will move their entries into this section.
+
+[blog]: https://software-carpentry.org/blog/
+[blog-archives]: https://software-carpentry.org/blog/categories/#SLUG
+[mailing-list]: http://lists.software-carpentry.org/listinfo/SLUG
+[mailing-list-archives]: http://lists.software-carpentry.org/pipermail/SLUG/

--- a/subcommittees/policy-CoC/README.md
+++ b/subcommittees/policy-CoC/README.md
@@ -14,7 +14,7 @@ Enforce the Code of Conduct (CoC) in all parts of the Carpentries community
 ## Contact
 
 * policy@carpentries.org to contact the committee
-* confidential@carpentries.org to report concerns regarding the CoC (will be kept private)
+* confidential@carpentries.org to report concerns regarding the CoC (confidential; recipient is C. MacDonnell)
 
 ## Current Members
 

--- a/subcommittees/policy-CoC/README.md
+++ b/subcommittees/policy-CoC/README.md
@@ -1,50 +1,26 @@
-# The NAME Subcommittee
+# The Code of Conduct Policy Subcommittee
 
 ## Purpose and Scope
 
-The Subcommittee FIXME...
+Enforce the Code of Conduct (CoC) in all parts of the Carpentries community
 
 ## What We Do
 
-FIXME
+* communicate with the Carpentries community about the CoC, as well as reporting and enforcement guidelines
+* review and respond to reports of CoC violations as deemed appropriate by the situation
 
-## Related Projects
+## Contact
 
-FIXME
-
-## Measuring Progress
-
-FIXME
-
-## Mailing List
-
-The best way to contact this Subcommittee is via the [mailing
-list][mailing-list], which is archived [here][mailing-list-archives].
-
-## Outreach
-
-We [blog][] about our ongoing and proposed activities.  Past blog
-posts are available [here][blog-archives].
-
-## Meetings
-
-We have occasional meetings.  Minutes of past meetings are available
-[here](minutes).
-
-## Join Us!
-
-We welcome new members to the Subcommittee.  If you are interested in
-joining our community-building efforts, please email the [mailing
-list](#mailing-list).
-
-## Steering Comittee Liaison
-
-* LIAISON_NAME (@LIAISON_GITHUB_USER, OTHER_LIAISON_CONTACT)
+* policy@carpentries.org
+* confidential@carpentries.org
 
 ## Current Members
 
-* MEMBER_1_NAME (@MEMBER_1_GITHUB_USER, OTHER_MEMBER_1_CONTACT)
-* OTHER_MEMBERS...
+* Pauline Barmby - chair (community)
+* Chris Hamm (community)
+* Simon Waldman (community)
+* Erin Becker (staff)
+* Jonah Duckles (staff)
 
 ## Past Members
 

--- a/subcommittees/policy-CoC/README.md
+++ b/subcommittees/policy-CoC/README.md
@@ -6,13 +6,15 @@ Enforce the Code of Conduct (CoC) in all parts of the Carpentries community
 
 ## What We Do
 
-* communicate with the Carpentries community about the CoC, as well as reporting and enforcement guidelines
+* communicate with the Carpentries community about the CoC via the [blog] 
 * review and respond to reports of CoC violations as deemed appropriate by the situation
+* update the [CoC reporting and enforcement guidelines](https://software-carpentry.org/conduct/) when necessary
+* due to the confidential nature of CoC reporting, meeting minutes will not be published publicly
 
 ## Contact
 
-* policy@carpentries.org
-* confidential@carpentries.org
+* policy@carpentries.org to contact the committee
+* confidential@carpentries.org to report concerns regarding the CoC (will be kept private)
 
 ## Current Members
 
@@ -28,6 +30,3 @@ We don't have any past members yet!  When current members leave the
 Subcommittee we will move their entries into this section.
 
 [blog]: https://software-carpentry.org/blog/
-[blog-archives]: https://software-carpentry.org/blog/categories/#SLUG
-[mailing-list]: http://lists.software-carpentry.org/listinfo/SLUG
-[mailing-list-archives]: http://lists.software-carpentry.org/pipermail/SLUG/


### PR DESCRIPTION
The README contains basic information about the subcommittee, but could be improved with contact information and updating the links at the bottom. 

We should also think about what (if any) documentation to include here, given the nature of the subcommittee. Perhaps just discussion on updates to policies?