### PR TITLE
*: Fix "comittee" -> "committee" typos

### DIFF
--- a/TaskForces/2017-CarpentryCon/README.md
+++ b/TaskForces/2017-CarpentryCon/README.md
@@ -22,7 +22,7 @@ progress on above items.
 We have occasional [meetings][].  Minutes of past meetings are
 available [here](minutes).
 
-## Steering Comittee Liaison
+## Steering Committee Liaison
 
 * Rayna Harris (@raynamharris)
 

--- a/TaskForces/fees/README.md
+++ b/TaskForces/fees/README.md
@@ -10,7 +10,7 @@ The Task Force makes recommendation for fee waivers to support the
 mission ad goals of the Software Carpentry Foundation (SCF) and it
 sustainability.
 
-## Steering Comittee Liaison
+## Steering Committee Liaison
 
 * Raniere Silva (@rgaiacs)
 

--- a/minutes/minutes-2015-04-09.md
+++ b/minutes/minutes-2015-04-09.md
@@ -208,7 +208,7 @@ Mentorship committee will discuss new name: no update
 
 **Finance:** Have drafted a financial report which will be made publicly available once the information has been firmed up. At the moment there are lots of uncertainties, because we are lacking info from NUMFocus. Balance at the moment seems to be around 45k. Our income is mostly from memberships and some from workshops. Our expenses are mostly Greg's salary. We have not been billed by NUMFocus yet. We have less income that we thought, but also less expenses. We still have fewer paid workshops than what we need to keep the lights on (target number here is 8 per month). Observation: we not coming close to the balance we wanted between teacher training, membership fees and workshop fees. No teacher training income this quarter. 
 
-No significant update from the other subcomittees beyond what is in the agenda. 
+No significant update from the other subcommittees beyond what is in the agenda.
 
 ## MSL Relationship Update [20 min, until 0:45]
 

--- a/minutes/minutes-2015-04-23.md
+++ b/minutes/minutes-2015-04-23.md
@@ -309,7 +309,7 @@ Motion: Approve the terms as described. Seconded. Passed.
 
 ## Micro Lesson [ 10 min, until 1:05 ]
 
-All agreed that this would be a good idea. We will let the mentoring comittee try this out on the latest batch of instructors.
+All agreed that this would be a good idea. We will let the mentoring committee try this out on the latest batch of instructors.
 
 Motion: Allow this. Seconded. Passed.
 
@@ -319,7 +319,7 @@ A current problem is that we have running pre and post questionnaires as a requi
 
 Karin also commented that this is probably going to be a common occurrence as the number of instructors increase. Thus, we need to consider this fee-wise in a more long-term context. One idea would be to charge something, but not full price for these. 
 
-Passed down to fee subcomittee for further evaluation.
+Passed down to fee subcommittee for further evaluation.
 
 ## Confidential Email [ 10 min, until 1:25 ]
 

--- a/subcommittees/assessment/README.md
+++ b/subcommittees/assessment/README.md
@@ -17,7 +17,7 @@ posts are available [here][blog-archives].
 We have occasional meetings.  Minutes of past meetings are available
 [here](minutes).
 
-## Steering Comittee Liaison
+## Steering Committee Liaison
 
 * Jason Williams (@JasonJWilliamsNY)
 

--- a/subcommittees/communication/README.md
+++ b/subcommittees/communication/README.md
@@ -7,7 +7,7 @@ Committee and many types of stakeholders including the public,
 potential workshop attendees, instructors, staff, and organizational
 members.
 
-## Steering Comittee Liaison
+## Steering Committee Liaison
 
 * Adina Howe (@adina)
 

--- a/subcommittees/finance/README.md
+++ b/subcommittees/finance/README.md
@@ -12,7 +12,7 @@ The Subcommittee reviews all financial activities and provides the
 Steering Commmittee with monthly reports on SCF’s financial
 performance against our budget goals and purposes.
 
-## Steering Comittee Liaison
+## Steering Committee Liaison
 
 * Jason Williams (@JasonJWilliamsNY)
 

--- a/subcommittees/lessons/README.md
+++ b/subcommittees/lessons/README.md
@@ -20,7 +20,7 @@ posts are available [here][blog-archives].
 The best way to contact this Subcommittee is via the [mailing
 list][mailing-list], which is archived [here][mailing-list-archives].
 
-## Steering Comittee Liaison
+## Steering Committee Liaison
 
 * Matt Davis (@jiffyclub)
 

--- a/subcommittees/local-group/README.md
+++ b/subcommittees/local-group/README.md
@@ -55,7 +55,7 @@ We welcome new members to the Subcommittee.  If you are interested in
 joining our community-building efforts, please email the [mailing
 list](#mailing-list).
 
-## Steering Comittee Liaison
+## Steering Committee Liaison
 
 * LIAISON_NAME (@LIAISON_GITHUB_USER, OTHER_LIAISON_CONTACT)
 

--- a/subcommittees/mentoring/README.md
+++ b/subcommittees/mentoring/README.md
@@ -40,7 +40,7 @@ We welcome new members to the subcommittee.  If you are interested in
 joining our community-building efforts, please email the [mailing
 list](#mailing-list).
 
-## Steering Comittee Liaison
+## Steering Committee Liaison
 
 * Rayna Harris (@raynamharris, [@raynamharris](https://twitter.com/raynamharris))
 

--- a/subcommittees/mentoring/minutes/minutes-2015-04-10.md
+++ b/subcommittees/mentoring/minutes/minutes-2015-04-10.md
@@ -259,7 +259,7 @@ BM: Use the "extras".
 
 SM: I think it more a matter of managing expectations, rather than expecting things to fit. This falls under mentoring instructors, no?
 
-KL suggests: feed this info to lesson subcomittee and ask them to think about it
+KL suggests: feed this info to lesson subcommittee and ask them to think about it
 
 ### Instructor Retention
 

--- a/subcommittees/partner-relations/README.md
+++ b/subcommittees/partner-relations/README.md
@@ -12,7 +12,7 @@ We [blog][] about our ongoing and proposed activities.  Past blog
 posts are available [here][blog-archives-1] and
 [here][blog-archives-2].
 
-## Steering Comittee Liaison
+## Steering Committee Liaison
 
 * Jason Williams (@JasonJWilliamsNY)
 

--- a/subcommittees/template/README.md
+++ b/subcommittees/template/README.md
@@ -37,7 +37,7 @@ We welcome new members to the Subcommittee.  If you are interested in
 joining our community-building efforts, please email the [mailing
 list](#mailing-list).
 
-## Steering Comittee Liaison
+## Steering Committee Liaison
 
 * LIAISON_NAME (@LIAISON_GITHUB_USER, OTHER_LIAISON_CONTACT)
 


### PR DESCRIPTION
Generated with:

    $ sed -i 's/Comittee/Committee/g' $(git grep -l Comittee)
    $ sed -i 's/comittee/committee/g' $(git grep -l comittee)