### PR TITLE
Adding summary from 2017 in person meeting

### DIFF
--- a/strategy/2017-update
+++ b/strategy/2017-update
@@ -1,0 +1,40 @@
+The Software Carpentry Steering Committee met in person on June 7-8 in Davis, California.   The committee members have unique journeys that brought them through the community to having a seat on the steering committee. Importantly, we have a unified vision for the future of the Software Carpentry Foundation and the roles of the steering committee. Below is a brief summary of the motions passes and detailed description of the five key areas over which the Steering Committee will continue to provide oversight. 
+ 
+Below, we describe the five key areas over which the Steering Committee provides oversight and provide a timeline for implementing our goals.
+
+## Areas with Steering Committee oversight
+ 
+#### Community
+We value the involvement of everyone in our community - learners, instructors, hosts, developers, maintainers, committee members, staff, partners, advocates, trainers, organizers, sponsors, advisors, and helpers. We are committed to creating a friendly and respectful place for learning, teaching and contributing. We will continue to support the Code of Conduct, which is at the heart of our community. Our mission is to continue growing and supporting a diverse and inclusive community. To that end, we have empowered a new Director of Community Engagement to accomplish this mission.
+ 
+#### Instructor training	
+We are committed to creating a community of practice around instruction. As we train new instructors and instructor trainers, we must also continue to support their professional development through a community of practice. We have empowered the Director of Instructor Training to expand the instructor training program to accommodate the needs of our community. Our strategic plan is to identify new instructor trainees and provide training opportunities while simultaneously working to grow our capacity to offer mentoring and other support to those new instructors.
+ 
+#### Curriculum
+The Software Carpentry lessons and workshops are the vehicle through which we teach best practices for scientific computing. Our curriculum evolves over time for many reasons, including changes in the needs of learners and turnover of lesson contributors. Part of our strategic plan is to support community involvement with lesson archival, lesson releases, lesson maintaince, lesson development, and other tasks related to curriculum.
+ 
+#### Finances
+The Software Carpentry Foundation is financially responsible for the organization. The Steering Committee will continue to govern the financial model and budget. We have designated a financial reserve to promote healthy and fiscally responsible operations. 
+ 
+#### Hiring staff 
+To achieve our mission, the steering committee will oversee the process of creating staff positions. We will evaluate the extent to which senior staff are carrying the strategic initiatives.  Senior staff will be responsible for evaluating junior staff members. 
+ 
+## Timeline for implementing the our goals
+ 
+#### Immediate concerns (now-six months)
+- Resolve issues with Windows Installer
+- Reconcile and resolve restructuring with Data Carpentry
+- Identify immediate concerns for lesson development and maintenance (with an eye towards a restructured Carpentries)
+- Create a curated list of resources for learners to continue building skills following workshops
+- Connect with members and community organizers, to develop local/regional communities
+ 
+#### Medium term (6-18 months)
+- Populating the map (in terms of workshops, instructors, members) with an emphasis on diversity 
+- Create feedback loops for improving lessons, including lesson templates
+- Local community building
+- Assess inclusiveness of online communities
+ 
+#### Long term (18+ months) 
+- Focus on communities of practice (for learners, instructors, trainers)
+- Solidify pathways of involvement for community members, associated with a mastery rubric of skills
+- Improve methods of documenting and recognizing contributions to the community (e.g., badging)


### PR DESCRIPTION
Even though this isn't a full strategic plan, this seems like the most appropriate place to store this summary. 

An alternative location would be in the "press releases" directory...