### PR TITLE
remove notes

### DIFF
--- a/subcommittees/mentoring/checklists-discussion-sessions.md
+++ b/subcommittees/mentoring/checklists-discussion-sessions.md
@@ -23,7 +23,6 @@ Discussion sessions are organized and conducted through this etherpad:
 
 ## After the discussion
 - [ ] Archive the etherpad by clicking on the star in the top right corner.  
-- [ ] Copy your notes to [this google doc](https://docs.google.com/document/d/1ifPM4pkS5HtQve68BCes_ewsG3wabSlYiwgan5RQWHU/) and label with the date and which session you led.  
 - [ ] Email checkout@carpentries.org with the names and affiliations of 
 instructor trainees who attended and participated in discussion.
 - [ ] Clear the information from your session (date/time, attendees, notes) from the etherpad. 


### PR DESCRIPTION
We originally asked people to copy the notes into a google doc so that we could use them for assessment and decision making. However, those notes have not been used consistently for the past year. I propose removing that step to remove overhead on discussion hosts.